### PR TITLE
fix: find pwd via shell

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -116,7 +116,7 @@ docker-builder:
 in-docker: docker-builder
 	@# Run the given make target inside Docker
 	docker run --rm \
-		-v $(PWD):/src \
+		-v $(shell pwd):/src \
 		--workdir /src \
 		-e HOME=/home/build \
 		-e ARCH=$(ARCH) \


### PR DESCRIPTION
for the container build. This is a more portable solution that works on more Linux distributions such as Fedora.