### PR TITLE
Remove instructions for local plugin not installed by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ make in-docker TARGET='dist' ARCH="aarch64"
 
 ## Installation
 
-SSH into your device and create the folder for the plugin and the installed games.
+SSH into your device and create the folder for the installed games.
 
 ```shell
 # You can find the device's IP in the Wi-Fi settings of your device
@@ -41,27 +41,9 @@ export DEVICE_IP=192.168.x.x
 ssh playtron@$DEVICE_IP
 ```
 ```shell
-mkdir -p ~/.local/share/playtron/plugins/local
 mkdir -p ~/.local/share/playtron/apps/local
 ```
 
-Create a file named `pluginmanifest.json`. This file should contain the following content depending on if the default installed plugin is used or a manually built plugin is used.
-
-```json
-{
-  "id": "local",
-  "startup_command": "playtron-plugin-local"
-}
-```
-```json
-{
-  "id": "local",
-  "startup_command": "/var/home/playtron/.local/share/playtron/plugins/local/playtron-plugin-local"
-}
-```
-
-Copy the manifest file to the same local plugin location:
-`scp pluginmanifest.json playtron@$DEVICE_IP:~/.local/share/playtron/plugins/local/`
 
 ## Setting up rsync on Windows
 


### PR DESCRIPTION
Local plugin is now correctly installed by default on beta 2 so these instructions can be removed