### PR TITLE
fix: get metadata only for entries that are directories

### DIFF
--- a/src/local/connector.rs
+++ b/src/local/connector.rs
@@ -68,6 +68,12 @@ impl LocalConnector {
         for library_path in self.get_library_paths() {
             for entry in fs::read_dir(library_path)? {
                 let dir_entry = entry?;
+                if dir_entry
+                    .metadata()
+                    .is_ok_and(|metadata| metadata.is_file())
+                {
+                    continue;
+                }
                 let app_id = dir_entry.file_name().to_str().unwrap().to_string();
                 let metadata = self.load_metadata(&app_id).await?;
                 let os: String = match metadata.get("os") {

--- a/src/utils/date.rs
+++ b/src/utils/date.rs
@@ -1,7 +1,6 @@
 use chrono::{DateTime, NaiveDateTime, Utc};
 use serde::Deserializer;
 
-    
 pub const ISO_FORMAT: &str = "%+";
 pub const DATE_ONLY_FORMAT: &str = "%Y-%m-%dT%H:%M:%S";
 
@@ -14,8 +13,6 @@ where
     })?;
     Ok(DateTime::<Utc>::from_naive_utc_and_offset(dt, Utc))
 }
-
-
 
 pub mod optional_date_serializer {
     use chrono::{DateTime, Utc};


### PR DESCRIPTION
also replaced some plain unwraps with more graceful implementation in case when user doesn't what they are doing