### PR TITLE
fix: Disable runtime by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,8 +93,9 @@ Example:
 name: Minecraft (Prism Launcher)
 executable: ./flatpak-launcher.sh
 os: linux
-runtime: false # default is true - apps run inside of container runtime
 ```
+
+If your game is Linux native and was built specifically against the Steam Runtime 3 (sniper), you should add `runtime: true` to gameinfo.yaml.
 
 Optionally, add an image to your game for the Playtron GameOS library. The image should be as close as possible to a 16:9 ratio and be in the highest quality possible (1080p recommended, maximum 4k)
 

--- a/src/types/app.rs
+++ b/src/types/app.rs
@@ -266,7 +266,7 @@ pub struct ItemMetadata {
     pub developers: Vec<String>,
     #[serde(alias = "type")]
     pub app_type: PlaytronAppType,
-    #[serde(default = "super::default_true")]
+    #[serde(default)]
     pub use_container_runtime: bool,
 }
 


### PR DESCRIPTION
Having local linux games running with the Steam runtime doesn't seem to be the primary use case of this plugin. It makes sense to have it enabled for the Steam plugin but in this case, it creates more work for anyone who doesn't want to run a game specifically built against the Steam runtime.