### PR TITLE
fix: Do not error on install requests

### DIFF
--- a/src/local/service.rs
+++ b/src/local/service.rs
@@ -47,7 +47,7 @@ impl LocalService {
             name: metadata
                 .get("name")
                 .and_then(|n| n.as_str())
-                .unwrap_or(&app_id.to_string())
+                .unwrap_or(app_id)
                 .to_string(),
             provider: LIBRARY_PROVIDER_ID.to_string(),
             app_type: crate::types::app::AppType::Game,
@@ -91,7 +91,7 @@ impl LocalService {
             name: metadata
                 .get("name")
                 .and_then(|n| n.as_str())
-                .unwrap_or(&app_id.to_string())
+                .unwrap_or(app_id)
                 .to_owned(),
             app_type: crate::types::app::PlaytronAppType::Game,
             providers: vec![PlaytronProvider {

--- a/src/plugin/library_provider.rs
+++ b/src/plugin/library_provider.rs
@@ -256,11 +256,15 @@ impl LibraryProvider {
     ///   Install "ssa{sv}" "Cinebench" "/dev/sda1" 2 'os' s windows 'language' s english
     async fn install(
         &self,
-        _app_id: &str,
+        app_id: &str,
         _dest_path: &str,
         _options: HashMap<String, zbus::zvariant::Value<'_>>,
+        #[zbus(signal_emitter)] emitter: SignalEmitter<'_>,
     ) -> fdo::Result<i32> {
-        Err(fdo::Error::Failed("Install is not supported".to_string()))
+        // Fake the install since it's manual.
+        // Only needed for launch configs
+        emitter.install_completed(app_id.to_string()).await?;
+        Ok(0)
     }
 
     /// Moves the given app to another disk and returns the new install directory.


### PR DESCRIPTION
If you create a launch config with a proton version not present on the system, the game has to go through the install process. 
This would fail with games installed with the plugin since it returned an error